### PR TITLE
Bugfixes

### DIFF
--- a/app/models/asset/export.rb
+++ b/app/models/asset/export.rb
@@ -5,7 +5,7 @@ module Asset::Export
     unless instance
       instance = SequencescapeClient.create_plate(class_name, {}) if class_name
     end
-    SequencescapeClient.update_extraction_attributes(instance, attributes_to_update)
+    SequencescapeClient.update_extraction_attributes(instance, attributes_to_update, user.username)
     facts.each {|f| f.update_attributes!(:up_to_date => true)}
     old_barcode = barcode
     update_attributes(:uuid => instance.uuid, :barcode => instance.barcode.ean13)

--- a/app/views/steps/_steps.html.erb
+++ b/app/views/steps/_steps.html.erb
@@ -13,7 +13,7 @@
                 <div id="step-<%= step.id %>" class="collapse <%= 'in' if params[:step_id].to_i==step.id %>">
                   <% unless @in_steps_finished %>
                   <table class="table">
-                    <thead><th>Action</th><th>Barcode</th><th>Fact<input type="checkbox" <%= 'checked="checked"' unless step.cancelled? %> class='pull-right'></th>
+                    <thead><th>Action</th><th>Barcode</th><th>Fact<input style="display:none;" type="checkbox" <%= 'checked="checked"' unless step.cancelled? %> class='pull-right'></th>
                     </thead>
                     <tbody>
                         <%= render :partial => 'operations/operations', :locals => {

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -29,8 +29,12 @@
       <td><%= user.username %></td>
       <td><%= user.fullname %></td>
       <td><%= user.role %></td>
-      <td><%= user.tube_printer.name %></td>
-      <td><%= user.plate_printer.name %></td>
+      <% if user.tube_printer %>
+        <td><%= user.tube_printer.name %></td>
+      <% end %>
+      <% if user.plate_printer %>
+        <td><%= user.plate_printer.name %></td>
+      <% end %>
         <td><%= bootstrap_link_to 'Show', user %></td>
         <td><%= bootstrap_link_to 'Edit', edit_user_path(user) %></td>
       </tr>

--- a/features/step_definitions/basic_definitions.rb
+++ b/features/step_definitions/basic_definitions.rb
@@ -227,7 +227,7 @@ When(/^I want to export a plate to Sequencescape$/) do
     def self.create_plate(name, opts)
       MockSequencescapePlateInstance.new
     end
-    def self.update_extraction_attributes(instance, attrs)
+    def self.update_extraction_attributes(instance, attrs, user)
       MockSequencescapePlateInstance.new
     end
   end

--- a/lib/sequencescape_client.rb
+++ b/lib/sequencescape_client.rb
@@ -27,8 +27,8 @@ class SequencescapeClient
     return nil
   end
 
-  def self.update_extraction_attributes(instance, attrs)
-    instance.extraction_attributes.create!(:attributes_update => attrs, :created_by => 'test')
+  def self.update_extraction_attributes(instance, attrs, username='test')
+    instance.extraction_attributes.create!(:attributes_update => attrs, :created_by => username)
   end
 
   def self.purpose_by_name(name)


### PR DESCRIPTION
Hides completely the functionality to cancel steps, as it is in a veryalpha state and should not be used in certain conditions.
Not try to show the printer in users#index if there is no printer in the
system for the user.
Send the username of the user to sequencescape.