### PR TITLE
Travis problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 before_install:
-  - gem install -v 1.16.2 bundler --no-rdoc --no-ri
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 before_script:
   - "export SECRET_KEY_BASE=`bundle exec rake secret`"
   - "bundle exec rake db:create RAILS_ENV=test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem install -v 1.16.2 bundler --no-rdoc --no-ri
 before_script:
   - "export SECRET_KEY_BASE=`bundle exec rake secret`"
   - "bundle exec rake db:create RAILS_ENV=test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ before_install:
 before_script:
   - "export SECRET_KEY_BASE=`bundle exec rake secret`"
   - "bundle exec rake db:create RAILS_ENV=test"
+services:
+- mysql


### PR DESCRIPTION
Last version of Bundler does not support older ruby versions, so to work with older versions of bundler (as it is required for current master branch using rails 4) some config for travis needed to be put in place. 

For reference, described for ruby in <https://docs.travis-ci.com/>

