### PR TITLE
Rollback rubygems https because current deployment project do not sup…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'http://rubygems.org'
 
 gem 'rdf-n3'
 gem 'tzinfo-data'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GIT
     psd_logger (0.1.6)
 
 GEM
-  remote: https://rubygems.org/
+  remote: http://rubygems.org/
   specs:
     ace-rails-ap (4.1.2)
     actionmailer (4.2.8)


### PR DESCRIPTION
Old capistrano deployment project is not compatible with rubygems https. Rolled back
Hopefully this will be the last change in current master (old version of samples extraction).