### PR TITLE
GPL-515 Edit Step Type page bug

### DIFF
--- a/app/assets/javascripts/condition_groups.js
+++ b/app/assets/javascripts/condition_groups.js
@@ -59,7 +59,7 @@
     };
 
     proto.checkFactToN3 = function(group, fact) {
-      return ["?"+group.getName(), ":"+fact.predicate, fact.object? ":"+fact.object : fact.literal].join("\t ")+" .";
+      return ["?"+group.getName(), ":"+fact.predicate, fact.object?'"""'+fact.object+ '"""': fact.literal].join("\t ")+" .";
     };
 
     proto.actionFactToN3 = function(group, fact) {

--- a/app/views/step_types/_form.html.erb
+++ b/app/views/step_types/_form.html.erb
@@ -1,6 +1,3 @@
-
-
-
 <%= bootstrap_form_for(step_type, :html => { :"data-psd-component-class" => "ConditionGroups", :"data-psd-component-parameters" => condition_groups_init_for_step_type(@step_type)}) do |f| %>
   <% if step_type.errors.any? %>
     <div id="error_explanation">
@@ -13,6 +10,7 @@
       </ul>
     </div>
   <% end %>
+
   <% readonly = params[:action] == 'show' %>
   <div class="field step_type_name">
     <%= f.text_field :name, :readonly => readonly %>
@@ -52,7 +50,6 @@
         >New Asset</a>
       </div>
     </div>
-
   </div>
 
 


### PR DESCRIPTION
add quotes around the 'object' in a fact when it is added in the edit step type page

- this prevents the page from crashing when you add facts with spaces in the 'object', e.g. 'purpose: thing with spaces'

Closes #109 