### PR TITLE
Raise error with message when not finding the template

### DIFF
--- a/app/models/label_template.rb
+++ b/app/models/label_template.rb
@@ -1,7 +1,7 @@
 class LabelTemplate < ApplicationRecord
   CLASS_TYPE_TEMPLATE_ALIASES = {
     'TubeRack' => 'Plate',
-    'Tube' => 'SampleTube'
+    'SampleTube' => 'Tube'
   }.freeze
 
   validates_presence_of :name, :external_id
@@ -11,6 +11,12 @@ class LabelTemplate < ApplicationRecord
     type = CLASS_TYPE_TEMPLATE_ALIASES.fetch(class_type, class_type)
 
     templates = where(template_type: type)
+
+    unless templates.count.positive?
+      raise %(
+        Could not find any label template for type \'#{type}\'. Please contact LIMS support to fix the problem
+      )
+    end
 
     templates_by_barcodetype = templates.select { |t| t.name.include?(barcodetype) }
 

--- a/spec/models/label_template_spec.rb
+++ b/spec/models/label_template_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LabelTemplate, type: :model do
+  context '#for_type' do
+    let!(:templates) do
+      [
+        create(:label_template, name: 'se_ean13_96plate', template_type: 'DEPRECATED_PLATE', external_id: 1),
+        create(:label_template, name: 'se_code128_96plate', template_type: 'Plate', external_id: 2),
+        create(:label_template, name: 'se_ean13_1dtube', template_type: 'DEPRECATED_TUBE', external_id: 3),
+        create(:label_template, name: 'se_code128_1dtube', template_type: 'Tube', external_id: 4),
+        create(:label_template, name: 'sqsc_96plate_label_template_code39', template_type: 'Plate', external_id: 5),
+        create(:label_template, name: 'se_vertical_code39_1dtube', template_type: 'Tube', external_id: 6)
+      ]
+    end
+    context 'when obtaining a template' do
+      it 'returns a valid template for each case' do
+        expect(LabelTemplate.for_type('Tube', 'ean13')).to eq([templates[3], templates[5]])
+        expect(LabelTemplate.for_type('Tube', 'code128')).to eq([templates[3]])
+        expect(LabelTemplate.for_type('Tube', 'code39')).to eq([templates[5]])
+        expect(LabelTemplate.for_type('Plate', 'ean13')).to eq([templates[1], templates[4]])
+        expect(LabelTemplate.for_type('Plate', 'code128')).to eq([templates[1]])
+        expect(LabelTemplate.for_type('Plate', 'code39')).to eq([templates[4]])
+      end
+    end
+    context 'when using the wrong template' do
+      it 'raise error' do
+        expect { LabelTemplate.for_type('Bubidibu', 'ean13') }.to raise_error
+      end
+    end
+    context 'when using the template of an alias labware type' do
+      it 'returns a valid template for each case' do
+        expect(LabelTemplate.for_type('SampleTube', 'ean13')).to eq([templates[3], templates[5]])
+        expect(LabelTemplate.for_type('SampleTube', 'code128')).to eq([templates[3]])
+        expect(LabelTemplate.for_type('SampleTube', 'code39')).to eq([templates[5]])
+        expect(LabelTemplate.for_type('TubeRack', 'ean13')).to eq([templates[1], templates[4]])
+        expect(LabelTemplate.for_type('TubeRack', 'code128')).to eq([templates[1]])
+        expect(LabelTemplate.for_type('TubeRack', 'code39')).to eq([templates[4]])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes RT748619

Changes proposed in this pull request:

* Raise error with a message on failure finding template
