### PR TITLE
Bugfix. Barcodes that cannot be transformed to ean13 fail.

### DIFF
--- a/app/channels/activity_channel.rb
+++ b/app/channels/activity_channel.rb
@@ -73,11 +73,14 @@ class ActivityChannel < ApplicationCable::Channel # rubocop:todo Style/Documenta
 
     # Adds a new input to the resolver, classifying it into UUID or human barcode
     def add_input(input)
+      return if input.nil? || input.length.zero?
       if TokenUtil.is_uuid?(input)
         @input_objects_uuids.push(BarcodeInput.new(input: input, raw_input: input, pos: _next_position))
       else
+        human_barcode = TokenUtil.human_barcode(input)
+        transformed_value = human_barcode.length.positive? ? human_barcode : input
         @input_objects_human_barcodes.push(
-          BarcodeInput.new(input: TokenUtil.human_barcode(input), raw_input: input, pos: _next_position)
+          BarcodeInput.new(input: transformed_value, raw_input: input, pos: _next_position)
         )
       end
     end

--- a/spec/channels/activity_channel_spec.rb
+++ b/spec/channels/activity_channel_spec.rb
@@ -163,6 +163,14 @@ RSpec.describe ActivityChannel, type: :channel do
         inputs.each { |barcode| resolver.add_input(barcode) }
         expect(resolver.resolved_assets.assets).to eq(assets)
       end
+
+      it 'can ignore nil inputs' do
+        expect(Asset).to receive(:find_or_import_assets_with_barcodes).with(human_barcodes).and_return(assets)
+        resolver = ActivityChannel::BarcodeInputResolver.new
+        inputs.each { |barcode| resolver.add_input(barcode) }
+        resolver.add_input(nil)
+        expect(resolver.resolved_assets.assets).to eq(assets)
+      end
     end
     context 'with mixed content' do
       let(:uuids) { [SecureRandom.uuid, SecureRandom.uuid] }

--- a/spec/channels/activity_channel_spec.rb
+++ b/spec/channels/activity_channel_spec.rb
@@ -151,6 +151,19 @@ RSpec.describe ActivityChannel, type: :channel do
         expect(resolver.resolved_assets.assets).to eq(assets)
       end
     end
+    context 'with inputs that fail when converting to human barcodes' do
+      let!(:assets) { [create(:asset, barcode: 'NT1767662F'), create(:asset, barcode: 'NT1767663G')] }
+      let(:wrong_human_barcode) { '1234' }
+      let(:human_barcodes) { assets.map(&:barcode).concat([wrong_human_barcode]) }
+      let(:inputs) { ['3981767662700', '3981767663714', wrong_human_barcode] }
+
+      it 'can resolve uuids' do
+        expect(Asset).to receive(:find_or_import_assets_with_barcodes).with(human_barcodes).and_return(assets)
+        resolver = ActivityChannel::BarcodeInputResolver.new
+        inputs.each { |barcode| resolver.add_input(barcode) }
+        expect(resolver.resolved_assets.assets).to eq(assets)
+      end
+    end
     context 'with mixed content' do
       let(:uuids) { [SecureRandom.uuid, SecureRandom.uuid] }
       let(:inputs) { ['human1', uuids[0], '3981767663714', 'human2', '3981767662700', uuids[1]] }


### PR DESCRIPTION
This is a bugfix on the bugfix itself.