### PR TITLE
DPL-670-8 Add Sequencescape API Key config for V2 API

### DIFF
--- a/lib/sequencescape_client_v2.rb
+++ b/lib/sequencescape_client_v2.rb
@@ -8,6 +8,9 @@ module SequencescapeClientV2
     # set the api base url in an abstract base class
     self.site = "#{Rails.configuration.ss_api_v2_uri}/api/v2/"
     self.sync = false
+
+    # set the api key in the header for all requests
+    connection_options[:headers] = { 'X-Sequencescape-Client-Id' => Rails.configuration.ss_authorisation }
   end
 
   class SequencescapeClientV2::Asset < SequencescapeClientV2::Model

--- a/spec/lib/sequencescape_client_v2_spec.rb
+++ b/spec/lib/sequencescape_client_v2_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require './lib/sequencescape_client_v2'
+
+RSpec.describe SequencescapeClientV2 do
+  describe 'SequencescapeClientV2::Model' do
+    it 'sets the api base url in an abstract base class' do
+      expect(SequencescapeClientV2::Model.site).to eq("#{Rails.configuration.ss_api_v2_uri}/api/v2/")
+    end
+
+    it 'sets the sync attribute to false' do
+      expect(SequencescapeClientV2::Model.sync).to be_falsey
+    end
+
+    it 'sets the api key in the connection options headers' do
+      headers = SequencescapeClientV2::Model.connection_options[:headers]
+      expect(headers['X-Sequencescape-Client-Id']).to eq(Rails.configuration.ss_authorisation)
+    end
+  end
+
+  # Checks a class using the SequencescapeClientV2::Model class has the correct data
+  describe 'SequencescapeClientV2::Plate' do
+    it 'sets the api base url in an abstract base class' do
+      expect(SequencescapeClientV2::Plate.site).to eq("#{Rails.configuration.ss_api_v2_uri}/api/v2/")
+    end
+
+    it 'sets the sync attribute to true' do
+      expect(SequencescapeClientV2::Plate.sync).to be_truthy
+    end
+
+    it 'sets the api key in the connection options headers' do
+      headers = SequencescapeClientV2::Plate.connection_options[:headers]
+      expect(headers['X-Sequencescape-Client-Id']).to eq(Rails.configuration.ss_authorisation)
+    end
+
+    it 'has the api key header set correctly in the requests' do
+      # We can assert that the resource has the correct api key in the headers by the fact it is
+      # being successfully stubbed
+      stub_request(:get, %r{api/v2/plates})
+        # If you changed this header key or value it would fail as it would not reflect reality
+        .with(headers: { 'X-Sequencescape-Client-Id' => 'test' })
+        .to_return(File.new('./spec/support/responses/sequencescape/v2/plate_uuid_response.txt'))
+      plate = SequencescapeClientV2::Plate.first
+      expect(plate.type).to eq('plates')
+    end
+  end
+end

--- a/spec/lib/sequencescape_client_v2_spec.rb
+++ b/spec/lib/sequencescape_client_v2_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe SequencescapeClientV2 do
       # being successfully stubbed
       stub_request(:get, %r{api/v2/plates})
         # If you changed this header key or value it would fail as it would not reflect reality
-        .with(headers: { 'X-Sequencescape-Client-Id' => 'test' })
+        .with(headers: { 'X-Sequencescape-Client-Id' => Rails.configuration.ss_authorisation })
         .to_return(File.new('./spec/support/responses/sequencescape/v2/plate_uuid_response.txt'))
       plate = SequencescapeClientV2::Plate.first
       expect(plate.type).to eq('plates')


### PR DESCRIPTION
Closes #273 

#### Changes proposed in this pull request

- adds api key header to sequencescape v2 requests

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
