### PR TITLE
Updated bundler version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ADD Gemfile /samples_extraction
 ADD Gemfile.lock /samples_extraction
 ADD package.json /samples_extraction
 ADD yarn.lock /samples_extraction
-RUN gem install bundler
+RUN gem install bundler -v 2.4.22
 RUN bundle install --jobs=5 --deployment --without development test
 RUN yarn install
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This installation procedure is prepared for a MacOS environment:
 1. Install all the dependencies for the project
 
 ```
-  # gem install bundler
+  # gem install bundler -v 2.4.22
 
   # bundle install
 
@@ -96,7 +96,9 @@ This installation procedure is prepared for a MacOS environment:
   # yarn
 ```
 
-2. From the project folder, run the command
+Note that for ruby 2.7, the latest supported version of bundler is 2.4.22
+
+1. From the project folder, run the command
 
 ```
   # rake secret


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

For ruby 2.7, the latest supported version of bundler is 2.4.22 . Updating the version allows passing Docker image building test on CI for samples extraction.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
