### PR TITLE
Y25-011 - Bump actions/cache to v4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
       - run: env
 
       - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: /var/lib/docker
           key: ${{ runner.os }}-docker-${{ hashFiles('Dockerfile') }}


### PR DESCRIPTION
This PR updates the actions/cache version to v4 in all workflows within this repository.